### PR TITLE
Truncate error message to prevent cookie overflow

### DIFF
--- a/lib/lims_client.rb
+++ b/lib/lims_client.rb
@@ -4,8 +4,8 @@ module LimsClient
 
   def self.post(url, params)
     r = Faraday.new(url: url, headers: { 'Content-Type': 'application/json' }).post('', params.to_json)
-    unless r.status>=200 && r.status<400
-    	raise "LimsClient post failed. Response status: #{r.status}. #{r.body}"
+    unless r.status >= 200 && r.status < 400
+    	raise "LimsClient post failed. Response status: #{r.status}. #{r.body.truncate(200)}"
     end
   end
 


### PR DESCRIPTION
This fixes the Rails error when posting to a Sequencescape that doesn't support Aker Jobs. The problem was caused because the response body was a whole webpage, which is then stored in a cookie to be displayed as a flash. A webpage is **way** too big to be stored in a cookie - hence the cookie overflow error!