### PR TITLE
Message changes

### DIFF
--- a/app/models/work_order.rb
+++ b/app/models/work_order.rb
@@ -251,14 +251,14 @@ class WorkOrder < ApplicationRecord
     end
   end
 
-  def generate_submitted_event
+  def generate_dispatched_event
     begin
       if active?
-        message = WorkOrderEventMessage.new(work_order: self, status: 'submitted')
+        message = WorkOrderEventMessage.new(work_order: self, status: 'dispatched')
         BrokerHandle.publish(message)
-        BillingFacadeClient.send_event(self, 'submitted')
+        BillingFacadeClient.send_event(self, 'dispatched')
       else
-        Rails.logger.error("Submitted event cannot be generated from a work order that is not active.")
+        Rails.logger.error("dispatched event cannot be generated from a work order that is not active.")
       end
     rescue => e
       Rails.logger.error e

--- a/app/models/work_plan.rb
+++ b/app/models/work_plan.rb
@@ -83,6 +83,7 @@ class WorkPlan < ApplicationRecord
         module_ids.each_with_index do |mid, j|
           WorkOrderModuleChoice.create!(work_order_id: wo.id, aker_process_modules_id: mid, position: j, selected_value: product_options_selected_values[i][j])
         end
+        BrokerHandle.publish(WorkOrderEventMessage.new(work_order: wo, status: 'queued'))
       end
     end
     work_orders.reload

--- a/app/services/update_plan_service.rb
+++ b/app/services/update_plan_service.rb
@@ -131,7 +131,7 @@ class UpdatePlanService
 
       if dispatch_order_id
         return false unless send_order(dispatch_order_id)
-        generate_submitted_event(dispatch_order_id)
+        generate_dispatched_event(dispatch_order_id)
       end
     end
 
@@ -434,9 +434,9 @@ private
     return true
   end
 
-   def generate_submitted_event(order_id)
+   def generate_dispatched_event(order_id)
     order = WorkOrder.find(order_id)
-    order.generate_submitted_event
+    order.generate_dispatched_event
   end
 
   def validate_modules(module_ids)

--- a/lib/event_message.rb
+++ b/lib/event_message.rb
@@ -125,14 +125,14 @@ class WorkOrderEventMessage < EventMessage
   end
 
   def metadata
-    if @status == 'submitted'
-      metadata_for_submitted
+    if @status == 'dispatched'
+      metadata_for_dispatched
     else
       metadata_for_concluded
     end
   end
 
-  def metadata_for_submitted
+  def metadata_for_dispatched
     plan = @work_order.work_plan
     {
       'work_order_id' => @work_order.id,

--- a/spec/lib/event_message_spec.rb
+++ b/spec/lib/event_message_spec.rb
@@ -153,8 +153,8 @@ RSpec.describe 'EventMessage' do
         end
       end
 
-      context 'when work order is submitted' do
-        let(:status) { 'submitted' }
+      context 'when work order is dispatched' do
+        let(:status) { 'dispatched' }
 
         it_behaves_like 'work order event message json'
 

--- a/spec/models/work_order_spec.rb
+++ b/spec/models/work_order_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe WorkOrder, type: :model do
   include WorkOrdersHelper
 
   let(:catalogue) { create(:catalogue) }
-  let(:product) { create(:product, name: 'Solylent Green', product_version: 3, catalogue: catalogue) }
+  let(:product) { create(:product, name: 'Soylent Green', product_version: 3, catalogue: catalogue) }
   let(:process) do
     pro = create(:aker_process, name: 'Baking')
     create(:aker_product_process, product: product, aker_process: pro, stage: 0)
@@ -27,6 +27,7 @@ RSpec.describe WorkOrder, type: :model do
     bfc = double('BillingFacadeClient')
     stub_const("BillingFacadeClient", bfc)
     stub_const('BrokerHandle', class_double('BrokerHandle'))
+    allow(BrokerHandle).to receive(:publish)
     allow(bfc).to receive(:validate_process_module_name) do |name|
       !name.starts_with? 'x'
     end

--- a/spec/models/work_order_spec.rb
+++ b/spec/models/work_order_spec.rb
@@ -268,23 +268,23 @@ RSpec.describe WorkOrder, type: :model do
     end
   end
 
-  describe '#generate_submitted_event' do
+  describe '#generate_dispatched_event' do
     context 'if work order does not have status active' do
       it 'generates an event using the BrokerHandle' do
         wo = build(:work_order)
-        allow(BillingFacadeClient).to receive(:send_event).with(wo, 'submitted')
+        allow(BillingFacadeClient).to receive(:send_event).with(wo, 'dispatched')
         expect(BrokerHandle).not_to receive(:publish).with(an_instance_of(WorkOrderEventMessage))
-        expect(Rails.logger).to receive(:error).with('Submitted event cannot be generated from a work order that is not active.')
-        wo.generate_submitted_event
+        expect(Rails.logger).to receive(:error).with('dispatched event cannot be generated from a work order that is not active.')
+        wo.generate_dispatched_event
       end
     end
 
     context 'if work order does have status active' do
       it 'generates an event using the BrokerHandle' do
         wo = build(:work_order, status: 'active')
-        allow(BillingFacadeClient).to receive(:send_event).with(wo, 'submitted')
+        allow(BillingFacadeClient).to receive(:send_event).with(wo, 'dispatched')
         expect(BrokerHandle).to receive(:publish).with(an_instance_of(WorkOrderEventMessage))
-        wo.generate_submitted_event
+        wo.generate_dispatched_event
       end
     end
   end

--- a/spec/services/update_plan_service_spec.rb
+++ b/spec/services/update_plan_service_spec.rb
@@ -853,7 +853,7 @@ RSpec.describe UpdatePlanService do
       @sent_event = false
       @finalised_set = false
       allow_any_instance_of(WorkOrder).to receive(:send_to_lims) { @sent_to_lims = true }
-      allow_any_instance_of(WorkOrder).to receive(:generate_submitted_event) { @sent_event = true }
+      allow_any_instance_of(WorkOrder).to receive(:generate_dispatched_event) { @sent_event = true }
       allow_any_instance_of(WorkOrder).to receive(:finalise_set) { @finalised_set = true }
       stub_project
       stub_stamps
@@ -1157,7 +1157,7 @@ RSpec.describe UpdatePlanService do
       @sent_to_lims = false
       @sent_event = false
       allow_any_instance_of(WorkOrder).to receive(:send_to_lims) { @sent_to_lims = true }
-      allow_any_instance_of(WorkOrder).to receive(:generate_submitted_event) { @sent_event = true }
+      allow_any_instance_of(WorkOrder).to receive(:generate_dispatched_event) { @sent_event = true }
       stub_project
       stub_stamps
       stub_broker_connection

--- a/spec/services/update_plan_service_spec.rb
+++ b/spec/services/update_plan_service_spec.rb
@@ -102,6 +102,7 @@ RSpec.describe UpdatePlanService do
 
   def stub_broker_connection
     stub_const('BrokerHandle', class_double('BrokerHandle', working?: true))
+    allow(BrokerHandle).to receive(:publish)
   end
 
   describe 'selecting a project' do


### PR DESCRIPTION
- Rename 'submitted' Work Order event to now be 'dispatched', so that term will appear in emails and to bring it in line with how we explain the process of dispatching a work order
- Send a 'queued' Work Order event when... a work order is queued