### PR TITLE
Minor UX

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,14 @@
 GIT
   remote: https://github.com/sanger/aker-billing-facade-client.git
-  revision: da00b4d5372165bdd4f4b24a4cfd0d302455ccd9
+  revision: 12f4b1391b4126c0371ae8894f947a42e5d4bff7
   specs:
-    aker-billing-facade-client (0.1.7)
+    aker-billing-facade-client (0.1.8)
       activemodel
       faraday
 
 GIT
   remote: https://github.com/sanger/aker-credentials.git
-  revision: 2d116d61e8ad0403cd12dc659221c75d39465ffe
+  revision: 29ce5d30af1a3a539cd5d83b2e1eed82bde359ab
   specs:
     aker_credentials_gem (0.2.6)
       activesupport
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: https://github.com/sanger/aker-matcon-client.git
-  revision: a67c20235900ef53fe0e1a38013f4e6038c6c6bb
+  revision: 650b8f48753f64c792a4493be77f3f92d71ae439
   specs:
     matcon_client (0.2.1)
       activemodel
@@ -35,13 +35,13 @@ GIT
 
 GIT
   remote: https://github.com/sanger/aker-projects-client-gem.git
-  revision: 8f60c7fca1fce4dc3567e9af32ea83b50cfae174
+  revision: 58fdc4523d80225a17dded1b5ac206e25d5aa7ea
   specs:
     aker-study-client (0.2.4)
 
 GIT
   remote: https://github.com/sanger/aker-set-client.git
-  revision: e11b04376d7b2cb16651a198915f5d0079919b3a
+  revision: bd6554b5c5d881ba17e4b7cb337f41ed0b16fb33
   specs:
     aker-set-client (0.2.1)
 
@@ -53,7 +53,7 @@ GIT
 
 GIT
   remote: https://github.com/sanger/aker-stamp-client.git
-  revision: 2dcfb979778a99fccd3370786d1f7d360f76219d
+  revision: 05e6fbe78ec9bb0fa36a898339cb2ca26d853048
   specs:
     aker_stamp_client (0.2.0)
 
@@ -121,7 +121,7 @@ GEM
     amq-protocol (2.3.0)
     arel (8.0.0)
     ast (2.4.0)
-    autoprefixer-rails (8.6.2)
+    autoprefixer-rails (8.6.5)
       execjs
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
@@ -135,11 +135,11 @@ GEM
     bootstrap_form (2.7.0)
     brakeman (4.3.1)
     builder (3.2.3)
-    bunny (2.10.0)
+    bunny (2.11.0)
       amq-protocol (~> 2.3.0)
     byebug (10.0.2)
     cancancan (2.2.0)
-    capybara (3.2.1)
+    capybara (3.3.1)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)
@@ -252,7 +252,7 @@ GEM
     multipart-post (2.0.0)
     net-ldap (0.16.1)
     nio4r (2.3.1)
-    nokogiri (1.8.2)
+    nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
     parallel (1.12.1)
     parser (2.4.0.2)
@@ -337,13 +337,13 @@ GEM
       rspec-mocks (~> 3.7.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.1)
-    rswag-api (2.0.3)
+    rswag-api (2.0.4)
       railties (>= 3.1, < 6.0)
-    rswag-specs (2.0.3)
+    rswag-specs (2.0.4)
       activesupport (>= 3.1, < 6.0)
       json-schema (~> 2.2)
       railties (>= 3.1, < 6.0)
-    rswag-ui (2.0.3)
+    rswag-ui (2.0.4)
       actionpack (>= 3.1, < 6.0)
       railties (>= 3.1, < 6.0)
     rubocop (0.51.0)
@@ -379,11 +379,10 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    sassc (1.11.4)
-      bundler
+    sassc (1.12.1)
       ffi (~> 1.9.6)
       sass (>= 3.3.0)
-    selenium-webdriver (3.12.0)
+    selenium-webdriver (3.13.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.2)
     sexp_processor (4.11.0)
@@ -399,7 +398,7 @@ GEM
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)
@@ -440,7 +439,7 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
-    webpacker (3.5.3)
+    webpacker (3.5.5)
       activesupport (>= 4.2)
       rack-proxy (>= 0.6.1)
       railties (>= 4.2)

--- a/app/views/work_plans/_work_plan.html.erb
+++ b/app/views/work_plans/_work_plan.html.erb
@@ -1,6 +1,6 @@
 <tr>
   <td><%= work_plan.id %></td>
-  <td><%= work_plan.product&.name || "None selected" %></td>
+  <td width="30%"><%= work_plan.product&.name || "None selected" %></td>
 
   <% if !work_plan.in_construction? %>
     <td><%= work_plan.work_order_ids.join(', ') %></td>

--- a/app/views/work_plans/_work_plan.html.erb
+++ b/app/views/work_plans/_work_plan.html.erb
@@ -17,7 +17,7 @@
   <td align="right">
     <% if work_plan.in_construction? %>
       <%= link_to 'Continue', work_plan_build_path(id: work_plan.wizard_step, work_plan_id: work_plan.id),
-            class: 'btn btn-primary', style: "margin-left: 10px; margin-bottom: 5px" %>
+            class: 'btn btn-primary' %>
       <%= link_to 'Delete', work_plan,
             method: :delete,
             class: 'btn btn-danger',

--- a/app/views/work_plans/index.html.erb
+++ b/app/views/work_plans/index.html.erb
@@ -13,7 +13,11 @@ My Work Plans
   <div class="col-md-12">
     <h4>Pending</h4>
     <p>These work plans haven't yet had their first work order dispatched. Partially created work plans are saved here for you.</p>
-    <%= render "work_plans_table", work_plans: @in_construction_plans, group: 'construction' %>
+    <% if @in_construction_plans.length == 0 %>
+      <p>You don't have any pending Work Plans.</p>
+    <% else %>
+      <%= render "work_plans_table", work_plans: @in_construction_plans, group: 'construction' %>
+    <% end %>
   </div>
 </div>
 
@@ -22,7 +26,11 @@ My Work Plans
     <h4>In Progress</h4>
     <p>These work plans have work orders that have been dispatched to Scientific Operations. Once they complete or cancel your
       work order you will be able to dispatch the next one.</p>
-    <%= render "work_plans_table", work_plans: @active_plans, group: 'active' %>
+      <% if @active_plans.length == 0 %>
+        <p>None of your Work Plans are currently in progress.</p>
+      <% else %>
+        <%= render "work_plans_table", work_plans: @active_plans, group: 'active' %>
+      <% end %>
   </div>
 </div>
 
@@ -30,7 +38,11 @@ My Work Plans
   <div class="col-md-12">
     <h4>Finished Work Plans</h4>
     <p>These work plans have had all of their work orders completed or cancelled by Scientific Operations.</p>
-    <%= render "work_plans_table", work_plans: @closed_plans, group: 'closed' %>
+    <% if @closed_plans.length == 0 %>
+      <p>You don't have any finished Work Plans.</p>
+    <% else %>
+      <%= render "work_plans_table", work_plans: @closed_plans, group: 'closed' %>
+    <% end %>
   </div>
 </div>
 
@@ -38,6 +50,10 @@ My Work Plans
   <div class="col-md-12">
     <h4>Cancelled</h4>
     <p>These work plans are those which you have cancelled.</p>
-    <%= render "work_plans_table", work_plans: @cancelled_plans, group: 'cancelled' %>
+    <% if @cancelled_plans.length == 0 %>
+      <p>You don't have any cancelled Work Plans.</p>
+    <% else %>
+      <%= render "work_plans_table", work_plans: @cancelled_plans, group: 'cancelled' %>
+    <% end %>
   </div>
 </div>


### PR DESCRIPTION
- Set Product Name column width to 30% of Work Plan tables, so a long product name doesn't take up most of the table and squash everything else
- Remove inline styles from Work Plan action buttons. This fixes one button being higher than the other.
- If there are no Work Plans to show in a given table, show a message saying that (instead of showing an empty table). This is now in line with the Reception app.