### PR TITLE
When creating work orders, create them all and then send the "queued" events

### DIFF
--- a/app/models/work_plan.rb
+++ b/app/models/work_plan.rb
@@ -84,10 +84,12 @@ class WorkPlan < ApplicationRecord
         module_ids.each_with_index do |mid, j|
           WorkOrderModuleChoice.create!(work_order_id: wo.id, aker_process_modules_id: mid, position: j, selected_value: product_options_selected_values[i][j])
         end
-        BrokerHandle.publish(WorkOrderEventMessage.new(work_order: wo, status: 'queued'))
       end
+
+      work_orders.reload
+      # Leave the event broadcasting till last, because it won't be rolled back
+      work_orders.each { |wo| BrokerHandle.publish(WorkOrderEventMessage.new(work_order: wo, status: 'queued')) }
     end
-    work_orders.reload
   end
 
   def name

--- a/config/initializers/broker_initializer.rb
+++ b/config/initializers/broker_initializer.rb
@@ -14,7 +14,9 @@ else
   # Create an "empty" class definition with fake methods to use when events are disabled
   BrokerHandle = Broker.new.tap do |obj|
     obj.instance_eval do
-      def publish(obj); end
+      def publish(obj)
+        # puts "***\nPUBLISHING\n#{obj.generate_json}\n***"
+      end
       def consume; end
       def working?; end
       def connected?; end


### PR DESCRIPTION
Don't send the event for any before they've all been created, because the transaction will not roll back the events.