### PR TITLE
Work order revisions

### DIFF
--- a/app/javascript/components/product_description.jsx
+++ b/app/javascript/components/product_description.jsx
@@ -406,7 +406,7 @@ class ProcessModulesSelectDropdowns extends React.Component {
 
     const {links, path} = this.props;
 
-    path.forEach((obj, index)=>{
+    path.forEach((obj, index) => {
       if (index == 0) {
         options = links.start;
       } else {
@@ -479,9 +479,10 @@ export class ProcessModuleParameters extends React.Component {
     if ((this.props.selectedOption.min_value || this.props.selectedOption.max_value)) {
       const caption = "Enter value between "+ this.props.selectedOption.min_value + " and "+this.props.selectedOption.max_value
       const name = "work_plan[work_order_module]["+this.props.selectedOption.id+"][selected_value]"
+      const disabled = !this.props.enabled
       return(
         <div className={this.classes()}>
-          <input autoComplete="off" value={this.state.selectedValue} type="text" name={name} className="form-control" placeholder={caption} onChange={this.onChange} />
+          <input autoComplete="off" disabled={disabled} value={this.state.selectedValue} type="text" name={name} className="form-control" placeholder={caption} onChange={this.onChange} />
           {this.renderFeedback(caption)}
         </div>
       )
@@ -517,7 +518,7 @@ class ProcessModuleSelectElement extends React.Component {
           { this.renderSelect(select_options, selection) }
         </div>
         <div className="col-md-3">
-          <ProcessModuleParameters selectedOption={selectedOption} selectedValueForChoice={this.props.selectedValueForChoice} />
+          <ProcessModuleParameters selectedOption={selectedOption} selectedValueForChoice={this.props.selectedValueForChoice} enabled={this.props.enabled} />
         </div>
       </div>
     )

--- a/app/models/concerns/linkable_to_sets.rb
+++ b/app/models/concerns/linkable_to_sets.rb
@@ -132,7 +132,7 @@ module ExternalRequests
     module_function :material_client
 
     def container_client
-      ExternalRequests::Containers.container_client
+      MatconClient::Container
     end
     module_function :container_client
 

--- a/app/models/work_plan.rb
+++ b/app/models/work_plan.rb
@@ -57,8 +57,6 @@ class WorkPlan < ApplicationRecord
       end
 
       work_orders.reload
-      # Leave the event broadcasting till last, because it won't be rolled back
-      work_orders.each { |wo| BrokerHandle.publish(WorkOrderEventMessage.new(work_order: wo, status: 'queued')) }
     end
   end
 

--- a/app/services/update_plan_service.rb
+++ b/app/services/update_plan_service.rb
@@ -98,7 +98,9 @@ class UpdatePlanService
             locked_set_uuid = @work_plan.work_orders.first.set_uuid
             work_order_ids = @work_plan.work_orders.map(&:id)
             WorkOrderModuleChoice.where(work_order_id: work_order_ids).each(&:destroy)
-            @work_plan.work_orders.destroy_all
+            @work_plan.work_orders.each(&:destroy) # use individual destroy to trigger proper cleanup (e.g. permissions)
+            @work_plan.work_orders.object.reload
+            @work_plan.work_orders.clear # draper collectiondecorator does not refresh
           end
 
           if update_order

--- a/app/services/update_plan_service.rb
+++ b/app/services/update_plan_service.rb
@@ -99,8 +99,12 @@ class UpdatePlanService
             work_order_ids = @work_plan.work_orders.map(&:id)
             WorkOrderModuleChoice.where(work_order_id: work_order_ids).each(&:destroy)
             @work_plan.work_orders.each(&:destroy) # use individual destroy to trigger proper cleanup (e.g. permissions)
-            @work_plan.work_orders.object.reload
-            @work_plan.work_orders.clear # draper collectiondecorator does not refresh
+            if @work_plan.work_orders.respond_to? :reload
+              @work_plan.work_orders.reload
+            else
+              @work_plan.work_orders.object.reload
+              @work_plan.work_orders.clear # draper collectiondecorator does not refresh
+            end
           end
 
           if update_order

--- a/app/services/work_order_splitter.rb
+++ b/app/services/work_order_splitter.rb
@@ -31,6 +31,8 @@ module WorkOrderSplitter
 
             after_create(job)
 
+            job.save!
+
             jobs << job
           end
 
@@ -43,7 +45,6 @@ module WorkOrderSplitter
         rollback
         return false
       end
-
       work_order.reload
       return true
     end

--- a/app/services/work_order_splitter.rb
+++ b/app/services/work_order_splitter.rb
@@ -37,12 +37,14 @@ module WorkOrderSplitter
           # Done last because you can't undo it
           lock_all_sets(work_order)
         end
-      rescue
+      rescue => e
+        Rails.logger.error "WorkOrderSplitter.split failed for work order #{work_order.id}"
+        Rails.logger.error ([e.message] + e.backtrace).join("\n   ")
         rollback
         return false
       end
 
-      return work_order
+      return true
     end
 
   protected

--- a/app/services/work_order_splitter.rb
+++ b/app/services/work_order_splitter.rb
@@ -44,6 +44,7 @@ module WorkOrderSplitter
         return false
       end
 
+      work_order.reload
       return true
     end
 

--- a/db/migrate/20180816103146_add_sent_queued_events_boolean_to_work_plan.rb
+++ b/db/migrate/20180816103146_add_sent_queued_events_boolean_to_work_plan.rb
@@ -1,0 +1,17 @@
+class AddSentQueuedEventsBooleanToWorkPlan < ActiveRecord::Migration[5.2]
+  def up
+    add_column :work_plans, :sent_queued_events, :boolean, null: false, default: false
+
+    # Assume that all the existing work plans that have work orders have already
+    # sent their events
+    WorkPlan.find_each do |plan|
+      unless plan.work_orders.empty?
+        plan.update_attributes(sent_queued_events: true)
+      end
+    end
+  end
+
+  def down
+    remove_column :work_plans, :sent_queued_events
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_07_150205) do
+ActiveRecord::Schema.define(version: 2018_08_16_103146) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -150,6 +150,7 @@ ActiveRecord::Schema.define(version: 2018_08_07_150205) do
     t.datetime "cancelled"
     t.uuid "data_release_strategy_id"
     t.string "priority", default: "standard", null: false
+    t.boolean "sent_queued_events", default: false, null: false
     t.index ["data_release_strategy_id"], name: "index_work_plans_on_data_release_strategy_id"
     t.index ["owner_email"], name: "index_work_plans_on_owner_email"
     t.index ["product_id"], name: "index_work_plans_on_product_id"

--- a/lib/event_message.rb
+++ b/lib/event_message.rb
@@ -177,7 +177,7 @@ class WorkOrderEventMessage < EventMessage
     else
       {
         'work_plan_id' => plan.id,
-        'drs_study_code' => plan.data_release_strategy.study_code
+        'drs_study_code' => plan.data_release_strategy&.study_code
       }
     end
   end

--- a/lib/event_message.rb
+++ b/lib/event_message.rb
@@ -66,6 +66,8 @@ end
 
 # A message specific to a work order
 class WorkOrderEventMessage < EventMessage
+  attr_reader :status
+
   def initialize(params)
     # For Work Order message
     @work_order = params.fetch(:work_order).decorate

--- a/spec/services/work_order_splitter_spec.rb
+++ b/spec/services/work_order_splitter_spec.rb
@@ -65,8 +65,8 @@ RSpec.describe 'WorkOrderSplitter' do
       expect(work_order.jobs.second.input_set_uuid).to eql("28d7c0e2-9935-41b1-a806-e9b22324d42d")
     end
 
-    it 'returns the Work Order' do
-      expect(splitter.split(work_order)).to be work_order
+    it 'returns true' do
+      expect(splitter.split(work_order)).to eq(true)
     end
 
     context 'when it fails half way through' do
@@ -91,6 +91,10 @@ RSpec.describe 'WorkOrderSplitter' do
 
       it 'doesn\'t create any Jobs (and deletes any created sets)' do
         expect { splitter.split(work_order) }.to change { work_order.jobs.count }.by(0)
+      end
+
+      it 'returns false' do
+        expect(splitter.split(work_order)).to eq(false)
       end
 
     end


### PR DESCRIPTION
Mainly, defer sending "work order queued" events until the first order is dispatched,
but incorporating several other bug fixes.